### PR TITLE
feat: Add macros from `combine-interception-macros` package

### DIFF
--- a/.github/package.xcworkspace/contents.xcworkspacedata
+++ b/.github/package.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "group:..">
+   </FileRef>
+</Workspace>

--- a/.github/package.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/.github/package.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/.github/package.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/.github/package.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,32 @@
+{
+  "pins" : [
+    {
+      "identity" : "swift-interception",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/capturecontext/swift-interception.git",
+      "state" : {
+        "revision" : "8e6231d629a3cb04b929c5a3ba2ea2797151d0b6",
+        "version" : "0.3.0"
+      }
+    },
+    {
+      "identity" : "swift-macro-toolkit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/stackotter/swift-macro-toolkit.git",
+      "state" : {
+        "revision" : "106daeb38eb3f52b1540aed981fc63fa22274576",
+        "version" : "0.3.1"
+      }
+    },
+    {
+      "identity" : "swift-syntax",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-syntax.git",
+      "state" : {
+        "revision" : "74203046135342e4a4a627476dd6caf8b28fe11b",
+        "version" : "509.0.0"
+      }
+    }
+  ],
+  "version" : 2
+}

--- a/.github/package.xcworkspace/xcshareddata/xcschemes/CombineInterception.xcscheme
+++ b/.github/package.xcworkspace/xcshareddata/xcschemes/CombineInterception.xcscheme
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1520"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "CombineInterception"
+               BuildableName = "CombineInterception"
+               BlueprintName = "CombineInterception"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "CombineInterception"
+            BuildableName = "CombineInterception"
+            BlueprintName = "CombineInterception"
+            ReferencedContainer = "container:">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/.github/package.xcworkspace/xcshareddata/xcschemes/CombineInterceptionMacros.xcscheme
+++ b/.github/package.xcworkspace/xcshareddata/xcschemes/CombineInterceptionMacros.xcscheme
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1520"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "CombineInterceptionMacros"
+               BuildableName = "CombineInterceptionMacros"
+               BlueprintName = "CombineInterceptionMacros"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "CombineInterceptionMacros"
+            BuildableName = "CombineInterceptionMacros"
+            BlueprintName = "CombineInterceptionMacros"
+            ReferencedContainer = "container:">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/.github/package.xcworkspace/xcshareddata/xcschemes/CombineInterceptionMacrosTests.xcscheme
+++ b/.github/package.xcworkspace/xcshareddata/xcschemes/CombineInterceptionMacrosTests.xcscheme
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1520"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "CombineInterceptionMacrosTests"
+               BuildableName = "CombineInterceptionMacrosTests"
+               BlueprintName = "CombineInterceptionMacrosTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/.github/package.xcworkspace/xcshareddata/xcschemes/CombineInterceptionTests.xcscheme
+++ b/.github/package.xcworkspace/xcshareddata/xcschemes/CombineInterceptionTests.xcscheme
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1520"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "CombineInterceptionTests"
+               BuildableName = "CombineInterceptionTests"
+               BlueprintName = "CombineInterceptionTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/.github/package.xcworkspace/xcshareddata/xcschemes/combine-interception-Package.xcscheme
+++ b/.github/package.xcworkspace/xcshareddata/xcschemes/combine-interception-Package.xcscheme
@@ -1,0 +1,130 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1520"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "CombineInterception"
+               BuildableName = "CombineInterception"
+               BlueprintName = "CombineInterception"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "CombineInterceptionMacros"
+               BuildableName = "CombineInterceptionMacros"
+               BlueprintName = "CombineInterceptionMacros"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "CombineInterceptionMacrosTests"
+               BuildableName = "CombineInterceptionMacrosTests"
+               BlueprintName = "CombineInterceptionMacrosTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "CombineInterceptionTests"
+               BuildableName = "CombineInterceptionTests"
+               BlueprintName = "CombineInterceptionTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "CombineInterceptionMacrosTests"
+               BuildableName = "CombineInterceptionMacrosTests"
+               BlueprintName = "CombineInterceptionMacrosTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "CombineInterceptionTests"
+               BuildableName = "CombineInterceptionTests"
+               BlueprintName = "CombineInterceptionTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "CombineInterception"
+            BuildableName = "CombineInterception"
+            BlueprintName = "CombineInterception"
+            ReferencedContainer = "container:">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/.github/package.xcworkspace/xcshareddata/xcschemes/combine-interception.xcscheme
+++ b/.github/package.xcworkspace/xcshareddata/xcschemes/combine-interception.xcscheme
@@ -1,0 +1,116 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1520"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "CombineInterception"
+               BuildableName = "CombineInterception"
+               BlueprintName = "CombineInterception"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "CombineInterceptionMacrosTests"
+               BuildableName = "CombineInterceptionMacrosTests"
+               BlueprintName = "CombineInterceptionMacrosTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "CombineInterceptionTests"
+               BuildableName = "CombineInterceptionTests"
+               BlueprintName = "CombineInterceptionTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "CombineInterceptionMacrosTests"
+               BuildableName = "CombineInterceptionMacrosTests"
+               BlueprintName = "CombineInterceptionMacrosTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "CombineInterceptionTests"
+               BuildableName = "CombineInterceptionTests"
+               BlueprintName = "CombineInterceptionTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "CombineInterception"
+            BuildableName = "CombineInterception"
+            BlueprintName = "CombineInterception"
+            ReferencedContainer = "container:">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,34 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - '*'
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  library-swift-latest:
+    name: Library
+    if: |
+      !contains(github.event.head_commit.message, '[ci skip]') &&
+      !contains(github.event.head_commit.message, '[ci skip test]') &&
+      !contains(github.event.head_commit.message, '[ci skip library-swift-latest]')
+    runs-on: macos-13
+    timeout-minutes: 30
+    strategy:
+      matrix:
+        config:
+          - debug
+          - release
+    steps:
+    - uses: actions/checkout@v4
+    - name: Select Xcode 15.2
+      run: sudo xcode-select -s /Applications/Xcode_15.2.app
+    - name: Run test
+      run: make test

--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,8 @@
 .DS_Store
 /.build
 /Packages
-/*.xcodeproj
 xcuserdata/
 DerivedData/
+.swiftpm/configuration/registries.json
 .swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
-Package.resolved
+.netrc

--- a/.swiftpm/xcode/xcshareddata/xcschemes/CombineInterception.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/CombineInterception.xcscheme
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1520"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "CombineInterception"
+               BuildableName = "CombineInterception"
+               BlueprintName = "CombineInterception"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "CombineInterception"
+            BuildableName = "CombineInterception"
+            BlueprintName = "CombineInterception"
+            ReferencedContainer = "container:">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/.swiftpm/xcode/xcshareddata/xcschemes/CombineInterceptionMacros.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/CombineInterceptionMacros.xcscheme
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1520"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "CombineInterceptionMacros"
+               BuildableName = "CombineInterceptionMacros"
+               BlueprintName = "CombineInterceptionMacros"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "CombineInterceptionMacros"
+            BuildableName = "CombineInterceptionMacros"
+            BlueprintName = "CombineInterceptionMacros"
+            ReferencedContainer = "container:">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/.swiftpm/xcode/xcshareddata/xcschemes/CombineInterceptionMacrosTests.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/CombineInterceptionMacrosTests.xcscheme
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1520"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "CombineInterceptionMacrosTests"
+               BuildableName = "CombineInterceptionMacrosTests"
+               BlueprintName = "CombineInterceptionMacrosTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/.swiftpm/xcode/xcshareddata/xcschemes/CombineInterceptionTests.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/CombineInterceptionTests.xcscheme
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1520"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "CombineInterceptionTests"
+               BuildableName = "CombineInterceptionTests"
+               BlueprintName = "CombineInterceptionTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/.swiftpm/xcode/xcshareddata/xcschemes/combine-interception-Package.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/combine-interception-Package.xcscheme
@@ -1,0 +1,130 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1520"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "CombineInterception"
+               BuildableName = "CombineInterception"
+               BlueprintName = "CombineInterception"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "CombineInterceptionMacros"
+               BuildableName = "CombineInterceptionMacros"
+               BlueprintName = "CombineInterceptionMacros"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "CombineInterceptionMacrosTests"
+               BuildableName = "CombineInterceptionMacrosTests"
+               BlueprintName = "CombineInterceptionMacrosTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "CombineInterceptionTests"
+               BuildableName = "CombineInterceptionTests"
+               BlueprintName = "CombineInterceptionTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "CombineInterceptionMacrosTests"
+               BuildableName = "CombineInterceptionMacrosTests"
+               BlueprintName = "CombineInterceptionMacrosTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "CombineInterceptionTests"
+               BuildableName = "CombineInterceptionTests"
+               BlueprintName = "CombineInterceptionTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "CombineInterception"
+            BuildableName = "CombineInterception"
+            BlueprintName = "CombineInterception"
+            ReferencedContainer = "container:">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/.swiftpm/xcode/xcshareddata/xcschemes/combine-interception.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/combine-interception.xcscheme
@@ -1,0 +1,116 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1520"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "CombineInterception"
+               BuildableName = "CombineInterception"
+               BlueprintName = "CombineInterception"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "CombineInterceptionMacrosTests"
+               BuildableName = "CombineInterceptionMacrosTests"
+               BlueprintName = "CombineInterceptionMacrosTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "CombineInterceptionTests"
+               BuildableName = "CombineInterceptionTests"
+               BlueprintName = "CombineInterceptionTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "CombineInterceptionMacrosTests"
+               BuildableName = "CombineInterceptionMacrosTests"
+               BlueprintName = "CombineInterceptionMacrosTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "CombineInterceptionTests"
+               BuildableName = "CombineInterceptionTests"
+               BlueprintName = "CombineInterceptionTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "CombineInterception"
+            BuildableName = "CombineInterception"
+            BlueprintName = "CombineInterception"
+            ReferencedContainer = "container:">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,59 @@
-format:
-	swift format --in-place --recursive \
-		./Package.swift ./Sources/CombineExtensions
+CONFIG = debug
+PLATFORM_IOS = iOS Simulator,id=$(call udid_for,iOS 17.2,iPhone \d\+ Pro [^M])
+PLATFORM_MACOS = macOS
+PLATFORM_MAC_CATALYST = macOS,variant=Mac Catalyst
+PLATFORM_TVOS = tvOS Simulator,id=$(call udid_for,tvOS 17,TV)
+PLATFORM_WATCHOS = watchOS Simulator,id=$(call udid_for,watchOS 10,Watch)
+
+default: test-all
+
+test-all:
+	$(MAKE) test
+	$(MAKE) test-docs
+
+test:
+	$(MAKE) CONFIG=debug test-library
+	$(MAKE) CONFIG=debug test-library-macros
+
+test-library:
+	for platform in "$(PLATFORM_IOS)" "$(PLATFORM_MACOS)" "$(PLATFORM_MAC_CATALYST)" "$(PLATFORM_TVOS)" "$(PLATFORM_WATCHOS)"; do \
+		echo "\nTesting library on $$platform\n" && \
+		(xcodebuild test \
+			-skipMacroValidation \
+			-configuration $(CONFIG) \
+			-workspace .github/package.xcworkspace \
+			-scheme CombineInterceptionTests \
+			-destination platform="$$platform" | xcpretty && exit 0 \
+		) \
+		|| exit 1; \
+	done;
+
+test-library-macros:
+	for platform in "$(PLATFORM_IOS)" "$(PLATFORM_MACOS)" "$(PLATFORM_MAC_CATALYST)" "$(PLATFORM_TVOS)" "$(PLATFORM_WATCHOS)"; do \
+		echo "\nTesting library-macros on $$platform\n" && \
+		(xcodebuild test \
+			-skipMacroValidation \
+			-configuration $(CONFIG) \
+			-workspace .github/package.xcworkspace \
+			-scheme CombineInterceptionMacrosTests \
+			-destination platform="$$platform" | xcpretty && exit 0 \
+		) \
+		|| exit 1; \
+	done;
+
+DOC_WARNINGS = $(shell xcodebuild clean docbuild \
+	-scheme Interception \
+	-destination platform="$(PLATFORM_IOS)" \
+	-quiet \
+	2>&1 \
+	| grep "couldn't be resolved to known documentation" \
+	| sed 's|$(PWD)|.|g' \
+	| tr '\n' '\1')
+test-docs:
+	@test "$(DOC_WARNINGS)" = "" \
+		|| (echo "xcodebuild docbuild failed:\n\n$(DOC_WARNINGS)" | tr '\1' '\n' \
+		&& exit 1)
+
+define udid_for
+$(shell xcrun simctl list devices available '$(1)' | grep '$(2)' | sort -r | head -1 | awk -F '[()]' '{ print $$(NF-3) }')
+endef

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,0 +1,32 @@
+{
+  "pins" : [
+    {
+      "identity" : "swift-interception",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/capturecontext/swift-interception.git",
+      "state" : {
+        "revision" : "8e6231d629a3cb04b929c5a3ba2ea2797151d0b6",
+        "version" : "0.3.0"
+      }
+    },
+    {
+      "identity" : "swift-macro-toolkit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/stackotter/swift-macro-toolkit.git",
+      "state" : {
+        "revision" : "106daeb38eb3f52b1540aed981fc63fa22274576",
+        "version" : "0.3.1"
+      }
+    },
+    {
+      "identity" : "swift-syntax",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-syntax.git",
+      "state" : {
+        "revision" : "74203046135342e4a4a627476dd6caf8b28fe11b",
+        "version" : "509.0.0"
+      }
+    }
+  ],
+  "version" : 2
+}

--- a/Package.swift
+++ b/Package.swift
@@ -17,12 +17,17 @@ let package = Package(
 			name: "CombineInterception",
 			type: .static,
 			targets: ["CombineInterception"]
-		)
+		),
+		.library(
+			name: "CombineInterceptionMacros",
+			type: .static,
+			targets: ["CombineInterceptionMacros"]
+		),
 	],
 	dependencies: [
 		.package(
 			url: "https://github.com/capturecontext/swift-interception.git",
-			.upToNextMinor(from: "0.2.0")
+			.upToNextMinor(from: "0.3.0")
 		)
 	],
 	targets: [
@@ -35,10 +40,25 @@ let package = Package(
 				)
 			]
 		),
+		.target(
+			name: "CombineInterceptionMacros",
+			dependencies: [
+				.product(
+					name: "_InterceptionMacros",
+					package: "swift-interception"
+				)
+			]
+		),
 		.testTarget(
 			name: "CombineInterceptionTests",
 			dependencies: [
 				.target(name: "CombineInterception"),
+			]
+		),
+		.testTarget(
+			name: "CombineInterceptionMacrosTests",
+			dependencies: [
+				.target(name: "CombineInterceptionMacros"),
 			]
 		),
 	]

--- a/README.md
+++ b/README.md
@@ -4,8 +4,6 @@
 
 Combine API for interception of objc selectors in Swift.
 
-Macros: [`combine-interception-macros`](https://github.com/capturecontext/combine-interception-macros)
-
 ## Usage
 
 ### Basic
@@ -15,13 +13,26 @@ Observe selectors on NSObject instances
 ```swift
 navigationController.intercept(_makeMethodSelector(
   selector: UINavigationController.popViewController,
-  signature: UINavigationController.popViewController
+  signature: navigationController.popViewController
 ))
 .sink { result in
   print(result.args) // `animated` flag
   print(result.output) // popped `UIViewController?`
 }
 ```
+
+You can also simplify creating method selector with `CombineInterceptionMacros` if you are open for macros
+
+```swift
+navigationController.intercept(
+  #methodSelector(UINavigationController.popViewController)
+).sink { result in
+  print(result.args) // `animated` flag
+  print(result.output) // popped `UIViewController?`
+}
+```
+
+>  Macros require `swift-syntax` compilation, so it will affect cold compilation time
 
 ### Library
 
@@ -30,6 +41,13 @@ If you use it to create a library it may be a good idea to export this one impli
 ```swift
 // Exports.swift
 @_exported import CombineInterception
+```
+
+It's a good idea to add a separate macros target to your library as well
+
+```swift
+// Exports.swift
+@_exported import CombineInterceptionMacros
 ```
 
 ## Installation
@@ -49,7 +67,7 @@ If you use SwiftPM for your project, you can add CombineInterception to your pac
 ```swift
 .package(
   url: "https://github.com/capturecontext/combine-interception.git", 
-  .upToNextMinor(from: "0.2.0")
+  .upToNextMinor(from: "0.3.0")
 )
 ```
 
@@ -61,6 +79,15 @@ Do not forget about target dependencies:
   package: "combine-interception"
 )
 ```
+
+```swift
+.product(
+  name: "CombineInterceptionMacros",
+  package: "combine-interception"
+)
+```
+
+
 
 ## License
 

--- a/Sources/CombineInterceptionMacros/Exports.swift
+++ b/Sources/CombineInterceptionMacros/Exports.swift
@@ -1,0 +1,2 @@
+@_exported import _InterceptionMacros
+@_exported import CombineInterception

--- a/Tests/CombineInterceptionMacrosTests/InterceptionMacrosTests.swift
+++ b/Tests/CombineInterceptionMacrosTests/InterceptionMacrosTests.swift
@@ -1,0 +1,173 @@
+import XCTest
+@testable import CombineInterceptionMacros
+
+final class InterceptionMacrosTests: XCTestCase {
+	func testNoInputWithOutput() {
+		let object = Object()
+		var _args: [Void] = []
+		var _outputs: [Int] = []
+		var _expectedOutputs: [Int] = []
+		var _count = 0
+
+		let cancellable = object.intercept(#methodSelector(Object.zero)).sink { result in
+			_args.append(result.args)
+			_outputs.append(result.output)
+			_count += 1
+		}
+
+		let runs = 3
+		for _ in 0..<runs {
+			_expectedOutputs.append(object.zero())
+		}
+
+		XCTAssertEqual(_count, runs)
+		XCTAssertEqual(_args.count, runs)
+		XCTAssertEqual(_outputs, _expectedOutputs)
+
+		cancellable.cancel()
+	}
+
+	func testInputWithNoOutput() {
+		let object = Object()
+		var _args: [Int] = []
+		var _outputs: [Void] = []
+		var _count = 0
+
+		let cancellable = object.intercept(#methodSelector(Object.discard)).sink { result in
+			_args.append(result.args)
+			_outputs.append(result.output)
+			_count += 1
+		}
+
+		let runs = 3
+		for i in 0..<runs { object.discard(i) }
+
+		XCTAssertEqual(_count, runs)
+		XCTAssertEqual(_args, .init(0..<runs))
+		XCTAssertEqual(_outputs.count, runs)
+
+		cancellable.cancel()
+	}
+
+	func testInputWithOutput() {
+		let object = Object()
+		var _args: [Int] = []
+		var _outputs: [Bool] = []
+		var _expectedOutputs: [Bool] = []
+		var _count = 0
+
+		let cancellable = object.intercept(#methodSelector(Object.booleanForInteger)).sink { result in
+			_args.append(result.args)
+			_outputs.append(result.output)
+			_count += 1
+		}
+
+		let runs = 3
+		for i in 0..<runs {
+			_expectedOutputs.append(object.booleanForInteger(i))
+		}
+
+		XCTAssertEqual(_count, runs)
+		XCTAssertEqual(_args, .init(0..<runs))
+		XCTAssertEqual(_outputs, _expectedOutputs)
+
+		cancellable.cancel()
+	}
+
+	func testSimpleMultipleInputsWithOutput() {
+		let object = Object()
+		var _args: [(Int, Int)] = []
+		var _outputs: [Bool] = []
+		var _expectedArgs: [(Int, Int)] = []
+		var _expectedOutputs: [Bool] = []
+		var _count = 0
+
+		let cancellable = object.intercept(#methodSelector(Object.booleanAndForTwoIntegers)).sink { result in
+			_args.append(result.args)
+			_outputs.append(result.output)
+			_count += 1
+		}
+
+		let outerRuns = 3
+		let innerRuns = 3
+		let runs = outerRuns * innerRuns
+		for i in 0..<outerRuns {
+			for j in 0..<innerRuns {
+				_expectedArgs.append((i, j))
+				_expectedOutputs.append(object.booleanAndForTwoIntegers(i, j))
+			}
+		}
+
+		XCTAssertEqual(_count, runs)
+		XCTAssertEqual(_args.map(Pair.init), _expectedArgs.map(Pair.init))
+		XCTAssertEqual(_outputs, _expectedOutputs)
+
+		cancellable.cancel()
+	}
+
+	func testMultipleInputsWithOutput() {
+		let object = Object()
+		var _args: [(Int, Bool)] = []
+		var _outputs: [String] = []
+		var _expectedArgs: [(Int, Bool)] = []
+		var _expectedOutputs: [String] = []
+		var _count = 0
+
+		let cancellable = object.intercept(#methodSelector(Object.toString)).sink { result in
+			_args.append(result.args)
+			_outputs.append(result.output)
+			_count += 1
+		}
+
+		let outerRuns = 3
+		let innerRuns = 3
+		let runs = outerRuns * innerRuns
+		for i in 0..<outerRuns {
+			for j in 0..<innerRuns {
+				_expectedArgs.append((i, j.isMultiple(of: 2)))
+				_expectedOutputs.append(object.toString(i, j.isMultiple(of: 2)))
+			}
+		}
+
+		XCTAssertEqual(_count, runs)
+		XCTAssertEqual(_args.map(Pair.init), _expectedArgs.map(Pair.init))
+		XCTAssertEqual(_outputs, _expectedOutputs)
+
+		cancellable.cancel()
+	}
+}
+
+fileprivate class Object: NSObject {
+	@discardableResult
+	@objc dynamic
+	func zero() -> Int { 0 }
+
+	@objc dynamic
+	func discard(_ value: Int) {}
+
+	@discardableResult
+	@objc dynamic
+	func booleanForInteger(_ value: Int) -> Bool {
+		value != 0
+	}
+
+	@objc dynamic
+	func booleanAndForTwoIntegers(_ first: Int, _ second: Int) -> Bool {
+		booleanForInteger(first) && booleanForInteger(second)
+	}
+
+	@objc dynamic
+	func toString(_ first: Int, _ second: Bool) -> String {
+		String(describing: (first, second))
+	}
+}
+
+fileprivate struct Pair<Left: Equatable, Right: Equatable>: Equatable {
+	var left: Left
+	var right: Right
+
+	init(_ pair: (Left, Right)) {
+		self.left = pair.0
+		self.right = pair.1
+	}
+}


### PR DESCRIPTION
Macros approach is aligned with https://github.com/pointfreeco/swift-dependencies
Now they are a part of this package, but have a separate target

Pros vs shared target:
- Optional use of macros, core features are available without use of macros (macros increase cold compilation time, so not everyone is down to depend on them)

Pros vs separate macros package:
- Much easier to maintain
- Easier to import

Cons vs separate macros package:
- swift-syntax has to be resolved even if client doesn't use macros (however compilation time is not affected if client opts-out macros)

Notes:
- This PR also sets up CI